### PR TITLE
Edited markdown to remove YMAL errors

### DIFF
--- a/_posts/2024-06-11-brumali24a.md
+++ b/_posts/2024-06-11-brumali24a.md
@@ -1,6 +1,6 @@
 ---
-title: A deep learning approach for distributed aggregative optimization with users’
-  Feedback
+title: 'A deep learning approach for distributed aggregative optimization with users’
+  Feedback'
 abstract: We propose a novel distributed data-driven scheme for online aggregative
   optimization, i.e., the framework in which agents in a network aim to cooperatively
   minimize the sum of local timevarying costs each depending on a local decision variable

--- a/_posts/2024-06-11-chatzikiriakos24a.md
+++ b/_posts/2024-06-11-chatzikiriakos24a.md
@@ -1,6 +1,6 @@
 ---
-title: Learning soft constrained MPC value functions: Efficient MPC design and implementation
-  providing stability and safety guarantees
+title: 'Learning soft constrained MPC value functions: Efficient MPC design and implementation
+  providing stability and safety guarantees'
 abstract: 'Model Predictive Control (MPC) can be applied to safety-critical control
   problems, providing closed-loop safety and performance guarantees. Application of
   MPC requires solving an optimization problem at every sampling instant, making it

--- a/_posts/2024-06-11-chen24a.md
+++ b/_posts/2024-06-11-chen24a.md
@@ -1,7 +1,7 @@
 ---
 title: Leveraging Hamilton-Jacobi PDEs with time-dependent Hamiltonians for continual
   scientific machine learning
-abstract: We address two major challenges in scientific machine learning (SciML):
+abstract: 'We address two major challenges in scientific machine learning (SciML):
   interpretability and computational efficiency. We increase the interpretability
   of certain learning processes by establishing a new theoretical connection between
   optimization problems arising from SciML and a generalized Hopf formula, which represents
@@ -19,7 +19,7 @@ abstract: We address two major challenges in scientific machine learning (SciML)
   our connection to develop a new Riccati-based methodology for solving these learning
   problems that is amenable to continual learning applications. We also provide some
   corresponding numerical examples that demonstrate the potential computational and
-  memory advantages our Riccati-based approach can provide.
+  memory advantages our Riccati-based approach can provide.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR

--- a/_posts/2024-06-11-cramer24a.md
+++ b/_posts/2024-06-11-cramer24a.md
@@ -1,6 +1,6 @@
 ---
-title: Tracking object positions in reinforcement learning: A metric for keypoint
-  detection
+title: 'Tracking object positions in reinforcement learning: A metric for keypoint
+  detection'
 abstract: 'Reinforcement learning (RL) for robot control typically requires a detailed
   representation of the environment state, including information about task-relevant
   objects not directly measurable. Keypoint detectors, such as spatial autoencoders
@@ -25,7 +25,7 @@ publisher: PMLR
 issn: 2640-3498
 id: cramer24a
 month: 0
-tex_title: "Tracking object positions in reinforcement learning: A metric for keypoint
+tex_title: "Tracking object positions in reinforcement learning: {A} metric for keypoint
   detection"
 firstpage: 104
 lastpage: 116

--- a/_posts/2024-06-11-dai24a.md
+++ b/_posts/2024-06-11-dai24a.md
@@ -19,7 +19,7 @@ publisher: PMLR
 issn: 2640-3498
 id: dai24a
 month: 0
-tex_title: "Physically consistent modeling \& identification of nonlinear friction
+tex_title: "Physically consistent modeling \\& identification of nonlinear friction
   with dissipative {G}aussian processes"
 firstpage: 1415
 lastpage: 1426

--- a/_posts/2024-06-11-dietrich24a.md
+++ b/_posts/2024-06-11-dietrich24a.md
@@ -1,6 +1,6 @@
 ---
 title: Nonconvex scenario optimization for data-driven reachability
-abstract: Many of the popular reachability analysis methods rely on the existence
+abstract: 'Many of the popular reachability analysis methods rely on the existence
   of system models. When system dynamics are uncertain or unknown, data-driven techniques
   must be utilized instead. In this paper, we propose an approach to data-driven reachability
   that provides a probabilistic guarantee of correctness for these systems through
@@ -9,7 +9,7 @@ abstract: Many of the popular reachability analysis methods rely on the existenc
   for estimating nonconvex reachable sets: (1) through the union of partition cells
   and (2) through the sum of radial basis functions. Additionally, we investigate
   numerical examples to demonstrate the capability and applicability of the introduced
-  methods to provide nonconvex reachable set approximations.
+  methods to provide nonconvex reachable set approximations.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR

--- a/_posts/2024-06-11-gautam24a.md
+++ b/_posts/2024-06-11-gautam24a.md
@@ -1,5 +1,5 @@
 ---
-title: Soft convex quantization: revisiting Vector Quantization with convex optimization
+title: 'Soft convex quantization: revisiting Vector Quantization with convex optimization'
 abstract: 'Vector Quantization (VQ) is a well-known technique in deep learning for
   extracting informative discrete latent representations. VQ-embedded models have
   shown impressive results in a range of applications including image and speech generation.

--- a/_posts/2024-06-11-kumawat24a.md
+++ b/_posts/2024-06-11-kumawat24a.md
@@ -1,6 +1,6 @@
 ---
 title: 'STEMFold: Stochastic temporal manifold for multi-agent interactions in the
-  presence of hidden agents
+  presence of hidden agents'
 abstract: Learning accurate, data-driven predictive models for multiple interacting
   agents following unknown dynamics is crucial in many real-world physical and social
   systems. In many scenarios, dynamics prediction must be performed under incomplete

--- a/_posts/2024-06-11-latafat24a.md
+++ b/_posts/2024-06-11-latafat24a.md
@@ -1,6 +1,6 @@
 ---
-title: On the convergence of adaptive first order methods: proximal gradient and
-  alternating minimization algorithms
+title: 'On the convergence of adaptive first order methods: Proximal gradient and
+  alternating minimization algorithms'
 abstract: Building upon recent works on linesearch-free adaptive proximal gradient
   methods, this paper proposes AdaPG, a framework that unifies and extends existing
   results by providing larger stepsize policies and improved lower bounds. Different

--- a/_posts/2024-06-11-mao24a.md
+++ b/_posts/2024-06-11-mao24a.md
@@ -19,7 +19,7 @@ publisher: PMLR
 issn: 2640-3498
 id: mao24a
 month: 0
-tex_title: "\\widetilde{O}(T^{-1}) {C}onvergence to (coarse) correlated equilibria
+tex_title: "$\\widetilde{O}(T^{-1})$ {C}onvergence to (coarse) correlated equilibria
   in full-information general-sum markov games"
 firstpage: 361
 lastpage: 374

--- a/_posts/2024-06-11-ohnishi24a.md
+++ b/_posts/2024-06-11-ohnishi24a.md
@@ -1,6 +1,6 @@
 ---
-title: Signatures meet dynamic programming: Generalizing Bellman equations for trajectory
-  following
+title: 'Signatures meet dynamic programming: Generalizing Bellman equations for trajectory
+  following'
 abstract: 'Path signatures have been proposed as a powerful representation of paths
   that efficiently captures the path’s analytic and geometric characteristics, having
   useful algebraic properties including fast concatenation of paths through tensor

--- a/_posts/2024-06-11-qin24a.md
+++ b/_posts/2024-06-11-qin24a.md
@@ -1,7 +1,7 @@
 ---
-title: Learning $ε$-Nash equilibrium stationary policies in stochastic games with
+title: Learning $\epsilon$-Nash equilibrium stationary policies in stochastic games with
   unknown independent chains using online mirror descent
-abstract: We study a subclass of n-player stochastic games, namely, stochastic games
+abstract: 'We study a subclass of n-player stochastic games, namely, stochastic games
   with independent chains and unknown transition matrices. In this class of games,
   players control their own internal Markov chains whose transitions do not depend
   on the states/actions of other players. However, players’ decisions are coupled
@@ -17,14 +17,14 @@ abstract: We study a subclass of n-player stochastic games, namely, stochastic g
   equilibrium policy, we show that the proposed algorithm in which players make their
   decisions independently and in a decentralized fashion converges asymptotically
   to the stable $\epsilon$-Nash equilibrium stationary policy with arbitrarily high
-  probability.
+  probability.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR
 issn: 2640-3498
 id: qin24a
 month: 0
-tex_title: "Learning \\epsilon-{N}ash equilibrium stationary policies in stochastic games
+tex_title: "Learning $\\epsilon$-{N}ash equilibrium stationary policies in stochastic games
   with unknown independent chains using online mirror descent"
 firstpage: 784
 lastpage: 795

--- a/_posts/2024-06-11-salehi24a.md
+++ b/_posts/2024-06-11-salehi24a.md
@@ -1,6 +1,6 @@
 ---
-title: Data-efficient, explainable and safe box manipulation: Illustrating the advantages
-  of physical priors in model-predictive control
+title: 'Data-efficient, explainable and safe box manipulation: Illustrating the advantages
+  of physical priors in model-predictive control'
 abstract: 'Model-based RL/control have gained significant traction in robotics. Yet,
   these approaches often remain data-inefficient and lack the explainability of hand-engineered
   solutions. This makes them difficult to debug/integrate in safety-critical settings.

--- a/_posts/2024-06-11-salzmann24a.md
+++ b/_posts/2024-06-11-salzmann24a.md
@@ -1,5 +1,5 @@
 ---
-title: Learning for CasADi: Data-driven Models in Numerical Optimization
+title: 'Learning for CasADi: Data-driven Models in Numerical Optimization'
 abstract: 'While real-world problems are often challenging to analyze analytically,
   deep learning excels in modeling complex processes from data. Existing optimization
   frameworks like CasADi facilitate seamless usage of solvers but face challenges

--- a/_posts/2024-06-11-tang24a.md
+++ b/_posts/2024-06-11-tang24a.md
@@ -1,6 +1,6 @@
 ---
-title: Uncertainty quantification of set-membership estimation in control and perception:
-  Revisiting the minimum enclosing ellipsoid
+title: 'Uncertainty quantification of set-membership estimation in control and perception:
+  Revisiting the minimum enclosing ellipsoid'
 abstract: Set-membership estimation (SME) outputs a set estimator that guarantees
   to cover the groundtruth. Such sets are, however, defined by (many) abstract (and
   potentially nonconvex) constraints and therefore difficult to manipulate. We present

--- a/_posts/2024-06-11-wang24b.md
+++ b/_posts/2024-06-11-wang24b.md
@@ -1,6 +1,6 @@
 ---
 title: Understanding the difficulty of solving Cauchy problems with PINNs
-abstract: Physics-Informed Neural Networks (PINNs) have gained popularity in scientific
+abstract: 'Physics-Informed Neural Networks (PINNs) have gained popularity in scientific
   computing in recent years. However, they often fail to achieve the same level of
   accuracy as classical methods in solving differential equations. In this paper,
   we aim to understand this issue from two perspectives in the case of Cauchy problems:
@@ -12,7 +12,7 @@ abstract: Physics-Informed Neural Networks (PINNs) have gained popularity in sci
   image sets. This, in turn, influences the existence of global minima and the regularity
   of the network. We demonstrate that when the global minimum does not exist, machine
   precision becomes the predominant source of achievable error in practice. We also
-  present numerical experiments in support of our theoretical claims.
+  present numerical experiments in support of our theoretical claims.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR

--- a/_posts/2024-06-11-wang24c.md
+++ b/_posts/2024-06-11-wang24c.md
@@ -1,5 +1,5 @@
 ---
-title: 'Towards bio-inspired control of aerial vehicle: {D}istributed aerodynamic parameters
+title: 'Towards bio-inspired control of aerial vehicle: Distributed aerodynamic parameters
   for state prediction'
 abstract: In an era where traditional flight control systems are increasingly strained
   by the demands of modern aerial missions, this research introduces a novel integration

--- a/_posts/2024-06-11-zhang24b.md
+++ b/_posts/2024-06-11-zhang24b.md
@@ -1,6 +1,6 @@
 ---
-title: Controlgym: large-scale control environments for benchmarking reinforcement
-  learning algorithms
+title: 'Controlgym: Large-Scale Control Environments for Benchmarking Reinforcement
+  Learning Algorithms'
 abstract: 'We introduce controlgym, a library of thirty-six industrial control settings,
   and ten infinite-dimensional partial differential equation (PDE)-based control problems.
   Integrated within the OpenAI Gym/Gymnasium (Gym) framework, controlgym allows direct
@@ -21,11 +21,11 @@ publisher: PMLR
 issn: 2640-3498
 id: zhang24b
 month: 0
-tex_title: "Controlgym: large-scale control environments for benchmarking reinforcement
-  learning algorithms"
-firstpage: 181
-lastpage: 196
-page: 181-196
+tex_title: "{Controlgym: Large-Scale Control Environments for Benchmarking Reinforcement
+  Learning Algorithms}"
+firstpage: 1
+lastpage: 16
+page: 1-16
 order: 1
 cycles: false
 bibtex_author: Zhang, Xiangyuan and Mao, Weichao and Mowlavi, Saviz and Benosman,

--- a/_posts/2024-06-11-zhang24b.md
+++ b/_posts/2024-06-11-zhang24b.md
@@ -21,11 +21,11 @@ publisher: PMLR
 issn: 2640-3498
 id: zhang24b
 month: 0
-tex_title: "{Controlgym: Large-Scale Control Environments for Benchmarking Reinforcement
-  Learning Algorithms}"
-firstpage: 1
-lastpage: 16
-page: 1-16
+tex_title: "Controlgym: {L}arge-scale control environments for benchmarking reinforcement
+  learning algorithms"
+firstpage: 181
+lastpage: 196
+page: 181-196
 order: 1
 cycles: false
 bibtex_author: Zhang, Xiangyuan and Mao, Weichao and Mowlavi, Saviz and Benosman,

--- a/_posts/2024-06-11-zhang24b.md
+++ b/_posts/2024-06-11-zhang24b.md
@@ -1,6 +1,6 @@
 ---
-title: 'Controlgym: Large-Scale Control Environments for Benchmarking Reinforcement
-  Learning Algorithms'
+title: 'Controlgym: Large-scale control environments for benchmarking reinforcement
+  learning algorithms'
 abstract: 'We introduce controlgym, a library of thirty-six industrial control settings,
   and ten infinite-dimensional partial differential equation (PDE)-based control problems.
   Integrated within the OpenAI Gym/Gymnasium (Gym) framework, controlgym allows direct

--- a/_posts/2024-06-11-zhou24a.md
+++ b/_posts/2024-06-11-zhou24a.md
@@ -30,10 +30,10 @@ publisher: PMLR
 issn: 2640-3498
 id: zhou24a
 month: 0
-tex_title: "{Expert with Clustering: Hierarchical Online Preference Learning Framework}"
-firstpage: 1
-lastpage: 12
-page: 1-12
+tex_title: "Expert with Clustering: {H}ierarchical Online Preference Learning Framework"
+firstpage: 707
+lastpage: 718
+page: 707-718
 order: 1
 cycles: false
 bibtex_author: Zhou, Tianyue and Cho, Jung-Hoon and Ardabili, Babak Rahimi and Tabkhi,

--- a/_posts/2024-06-11-zhou24a.md
+++ b/_posts/2024-06-11-zhou24a.md
@@ -1,5 +1,5 @@
 ---
-title: Expert with clustering: Hierarchical online preference learning framework
+title: 'Expert with Clustering: Hierarchical Online Preference Learning Framework'
 abstract: 'Emerging mobility systems are increasingly capable of recommending options
   to mobility users, to guide them towards personalized yet sustainable system outcomes.
   Even more so than the typical recommendation system, it is crucial to minimize regret,
@@ -12,9 +12,9 @@ abstract: 'Emerging mobility systems are increasingly capable of recommending op
   advice. EWC efficiently utilizes hierarchical user information and incorporates
   a novel Loss-guided Distance metric. This metric is instrumental in generating more
   representative cluster centroids, thereby enhancing the performance of recommendation
-  systems. In a recommendation scenario with \(N\){users}, \(T\){rounds} per user,
-  and \(K\){options}, our algorithm achieves a regret bound of \(O(N\sqrt{T\log K}
-  + NT)\). This bound consists of two parts: the first term is the regret from the
+  systems. In a recommendation scenario with $N${users}, $T${rounds} per user,
+  and $K${options}, our algorithm achieves a regret bound of $O(N\sqrt{T\log K}
+  + NT)$. This bound consists of two parts: the first term is the regret from the
   Hedge algorithm, and the second term depends on the average loss from clustering.
   The algorithm performs with low regret, especially when a latent hierarchical structure
   exists among users. This regret bound underscores the theoretical and experimental
@@ -30,10 +30,10 @@ publisher: PMLR
 issn: 2640-3498
 id: zhou24a
 month: 0
-tex_title: "Expert with clustering: {H}ierarchical online preference learning framework"
-firstpage: 707
-lastpage: 718
-page: 707-718
+tex_title: "{Expert with Clustering: Hierarchical Online Preference Learning Framework}"
+firstpage: 1
+lastpage: 12
+page: 1-12
 order: 1
 cycles: false
 bibtex_author: Zhou, Tianyue and Cho, Jung-Hoon and Ardabili, Babak Rahimi and Tabkhi,

--- a/_posts/2024-06-11-zhou24a.md
+++ b/_posts/2024-06-11-zhou24a.md
@@ -1,5 +1,5 @@
 ---
-title: 'Expert with Clustering: Hierarchical Online Preference Learning Framework'
+title: 'Expert with clustering: Hierarchical online preference learning framework'
 abstract: 'Emerging mobility systems are increasingly capable of recommending options
   to mobility users, to guide them towards personalized yet sustainable system outcomes.
   Even more so than the typical recommendation system, it is crucial to minimize regret,


### PR DESCRIPTION
Updated .md files by including single quotes (' ') around paper titles to remove YAML errors caused by disallowed characters